### PR TITLE
Parse dates to UTC

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hadynz/kindle-clippings",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Package for parsing a MyClippings.txt file obtained from a Kindle and organizing it",
   "author": "Hady Osman <hadyos@gmail.com>",
   "license": "MIT",
@@ -8,7 +8,7 @@
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hadynz/KindleClippings"
+    "url": "git+https://github.com/hadynz/kindle-clippings"
   },
   "scripts": {
     "test": "npm run lint && jest",

--- a/src/blocks/ParsedBlock.spec.ts
+++ b/src/blocks/ParsedBlock.spec.ts
@@ -1,10 +1,5 @@
 import { RawBlock } from './RawBlock';
-import {
-  ParsedBlock,
-  EntryType,
-  Range,
-  parseDateOfCreation,
-} from './ParsedBlock';
+import { ParsedBlock, EntryType, Range, parseToUtcDate } from './ParsedBlock';
 
 interface TestData {
   entry: RawBlock;
@@ -222,30 +217,30 @@ describe('parseDateOfCreation', () => {
   test.each([
     [
       'Added on Monday, April 18, 2016 7:28:27 AM',
-      new Date('2016-04-18T07:28:27'),
+      new Date('2016-04-18T07:28:27Z'),
     ],
     [
       'Añadido el sábado, 12 de octubre de 2019 0:37:31', // Spanish
-      new Date('2019-10-12T00:37:31'),
+      new Date('2019-10-12T00:37:31Z'),
     ],
     [
       'Ajouté le mercredi 16 août 2017 02:14:10', // French
-      new Date('2017-08-16T02:14:10'),
+      new Date('2017-08-16T02:14:10Z'),
     ],
     [
       'Adicionado: sexta-feira, 29 de novembro de 2019 18:00:13', // Portuguese
-      new Date('2019-11-29T18:00:13'),
+      new Date('2019-11-29T18:00:13Z'),
     ],
     [
       'Aggiunto in data lunedì 8 marzo 2021 22:52:57', // Italian
-      new Date('2021-03-08T22:52:57'),
+      new Date('2021-03-08T22:52:57Z'),
     ],
     ['Invalid date', undefined],
     ['', undefined],
   ])(
     'Formats "%s" as "%o"',
     (dateString: string, expected: Date | undefined) => {
-      const actual = parseDateOfCreation(dateString);
+      const actual = parseToUtcDate(dateString);
       expect(actual).toEqual(expected);
     }
   );

--- a/src/blocks/ParsedBlock.ts
+++ b/src/blocks/ParsedBlock.ts
@@ -32,16 +32,14 @@ const toNumber = (value: string): number | undefined => {
   return Number(value) || undefined;
 };
 
-export const parseDateOfCreation = (
-  serializedDate: string
-): Date | undefined => {
-  const parseAsEn = moment(serializedDate);
+export const parseToUtcDate = (serializedDate: string): Date | undefined => {
+  const parseAsEn = moment.utc(serializedDate);
   if (parseAsEn.isValid()) {
     return parseAsEn.toDate();
   }
 
   for (const locale of ['it', 'fr', 'es', 'pt']) {
-    const parseAsI18l = moment(serializedDate, 'LL LTS', locale);
+    const parseAsI18l = moment.utc(serializedDate, 'LL LTS', locale);
     if (parseAsI18l.isValid()) {
       return parseAsI18l.toDate();
     }
@@ -155,7 +153,7 @@ export class ParsedBlock {
   }
 
   private parseDateOfCreation(dateMetadata: string) {
-    return parseDateOfCreation(dateMetadata);
+    return parseToUtcDate(dateMetadata);
   }
 
   private parseEntryType(pageMetadata: string): EntryType {


### PR DESCRIPTION
Just like a typical REST contract, best practice is to always communicate any dates as UTC 